### PR TITLE
Prefer __dir__ over __FILE__

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,4 +31,4 @@ end
 RSpec.configure { |c| c.include RSpecMixinExample }
 
 set :environment, :test
-set :root, File.join(File.dirname(__FILE__), 'app')
+set :root, File.join(__dir__, 'app')


### PR DESCRIPTION
This PR refactors the spec helper to use the `__dir__` method consistently.