### PR TITLE
CI: Add Ruby 3.4. Drop Ruby 3.0, Ruby 3.1, from test matrix.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,10 +43,9 @@ test_task:
 
   container:
     matrix:
-      image: ruby:3.0
-      image: ruby:3.1
       image: ruby:3.2
       image: ruby:3.3
+      image: ruby:3.4
 
   test_script: bundle exec rspec
 


### PR DESCRIPTION
This PR updates the test matrix, to include Ruby versions that are current and which the ri18n gem supports.

Relevant snippet from #76.

```
Because every version of r18n-core depends on Ruby >= 3.2, < 3.5
  and Gemfile depends on r18n-core >= 0,
  Ruby >= 3.2, < 3.5 is required.
```

Fixes #76 